### PR TITLE
Route json crash fix

### DIFF
--- a/src/Ducks/Duck.h
+++ b/src/Ducks/Duck.h
@@ -368,8 +368,14 @@ class Duck {
      */
     static bool sendHealth(void* p){
       Duck* duckInstance = static_cast<Duck*>(p);
-      std::string message = "C:" + std::to_string(duckInstance->counter) + "|" + "FM:" + std::to_string(freeMemory());
-      int err = duckInstance->sendData(topics::health, message);
+
+      JsonDocument doc;
+      doc["C"] = std::to_string(duckInstance->counter);
+      doc["FM"] = std::to_string(freeMemory());
+      std::string jsonString;
+      serializeJson(doc, jsonString);
+        
+      int err = duckInstance->sendData(topics::health, jsonString);
       if (err != DUCK_ERR_NONE) {
         duckInstance->counter++;
         loginfo_ln("[DUCK] health message failed to send.");

--- a/src/routing/RouteJSON.h
+++ b/src/routing/RouteJSON.h
@@ -49,11 +49,14 @@ class RouteJSON {
             }
             origin = json["origin"].as<const char*>();
             destination = json["destination"].as<const char*>();
-            logdbg_ln("Built RouteJSON from packet data: %s",json.as<std::string>().c_str());
+            const std::string serialized = asString();
+            logdbg_ln("Built RouteJSON from packet data: %s", serialized.c_str());
         }
 
         std::string asString(){
-            return json.as<std::string>();
+            std::string out;
+            serializeJson(json, out);
+            return out;
         }
 
         std::string convertReqToRep(){
@@ -67,7 +70,7 @@ class RouteJSON {
             std::string log;
             serializeJson(json, log);
 
-            return json.as<std::string>();
+            return asString();
         }
         Duid getOrigin(){
             Duid originDuid;
@@ -95,7 +98,7 @@ class RouteJSON {
             serializeJson(json, log);
             logdbg_ln("RREQ: %s", log.c_str());
 #endif
-            return json.as<std::string>();
+            return asString();
             //add rssi snr
         }
 
@@ -131,7 +134,7 @@ class RouteJSON {
         serializeJson(json, log);
         logdbg_ln("Packet: %s", log.c_str());
 
-        return json.as<std::string>();
+        return asString();
     }
 
   private:


### PR DESCRIPTION
This fixes a crash in MamaDuck route-packet handling on ESP32. RouteJSON was converting ArduinoJson::JsonDocument to std::string via json.as<std::string>(), which shows up in the crash backtrace and appears to corrupt heap state during routed RX processing.
The change switches those conversions to explicit serializeJson(...), which is the safer/standard way to materialize JSON text on this target.